### PR TITLE
responders move with evenly distance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,11 +115,6 @@
         <!-- Testing -->
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-web-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
             <scope>test</scope>
         </dependency>
@@ -164,10 +159,6 @@
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-web-client</artifactId>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/redhat/cajun/navy/responder/simulator/data/DistanceHelper.java
+++ b/src/main/java/com/redhat/cajun/navy/responder/simulator/data/DistanceHelper.java
@@ -1,0 +1,79 @@
+package com.redhat.cajun.navy.responder.simulator.data;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ *  Reference: http://www.movable-type.co.uk/scripts/latlong.html
+ */
+public class DistanceHelper {
+
+    static final int R = 6371; // Radius of the earth
+
+    public static double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2) + Math.cos(Math.toRadians(lat1))
+                * Math.cos(Math.toRadians(lat2)) * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c * 1000;
+    }
+
+    public static double calculateDistance(Coordinate c1, Coordinate c2) {
+        return calculateDistance(c1.lat, c1.lon, c2.lat, c2.lon);
+    }
+
+    public static Coordinate calculateIntermediateCoordinate(Coordinate c1, Coordinate c2, double distance) {
+
+        double latR1 = Math.toRadians(c1.lat);
+        double latR2 = Math.toRadians(c2.lat);
+        double lonR1 = Math.toRadians(c1.lon);
+        double longDiff= Math.toRadians(c2.lon-c1.lon);
+        double y= Math.sin(longDiff)*Math.cos(latR2);
+        double x=Math.cos(latR1)*Math.sin(latR2)-Math.sin(latR1)*Math.cos(latR2)*Math.cos(longDiff);
+
+        double bearing = (Math.toDegrees(Math.atan2(y, x))+360)%360;
+
+        double bearingR = Math.toRadians(bearing);
+
+        double distFrac = distance / (R * 1000);
+
+        double a = Math.sin(distFrac) * Math.cos(latR1);
+        double latDest = Math.asin(Math.sin(latR1) * Math.cos(distFrac) + a * Math.cos(bearingR));
+        double lonDest = lonR1 + Math.atan2(Math.sin(bearingR) * a, Math.cos(distFrac) - Math.sin(latR1) * Math.sin(latDest));
+
+        return new Coordinate(round(Math.toDegrees(latDest),4), round(Math.toDegrees(lonDest), 4));
+
+    }
+
+    private static double round(double value, int places) {
+        if (places < 0) throw new IllegalArgumentException();
+
+        BigDecimal bd = new BigDecimal(Double.toString(value));
+        bd = bd.setScale(places, RoundingMode.HALF_UP);
+        return bd.doubleValue();
+    }
+
+    public static class Coordinate {
+
+        private double lat;
+
+        private double lon;
+
+        public Coordinate(double lat, double lon) {
+            this.lat = lat;
+            this.lon = lon;
+        }
+
+        public double getLat() {
+            return lat;
+        }
+
+        public double getLon() {
+            return lon;
+        }
+    }
+
+}

--- a/src/main/java/com/redhat/cajun/navy/responder/simulator/data/Mission.java
+++ b/src/main/java/com/redhat/cajun/navy/responder/simulator/data/Mission.java
@@ -1,11 +1,13 @@
 package com.redhat.cajun.navy.responder.simulator.data;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import io.vertx.core.json.Json;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
-import java.util.*;
-import rx.Observable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.vertx.core.json.Json;
 
 public class Mission {
     private String id;
@@ -156,6 +158,8 @@ public class Mission {
         r.setMissionId(id);
         r.setIncidentId(incidentId);
         r.setQueue(new LinkedList<>(getSteps()));
+        r.setCurrentLat(responderStartLat);
+        r.setCurrentLon(responderStartLong);
         return r;
     }
 

--- a/src/test/java/com/redhat/cajun/navy/responder/simulator/data/DistanceHelperTest.java
+++ b/src/test/java/com/redhat/cajun/navy/responder/simulator/data/DistanceHelperTest.java
@@ -1,0 +1,16 @@
+package com.redhat.cajun.navy.responder.simulator.data;
+
+import org.junit.Test;
+
+public class DistanceHelperTest {
+
+    @Test
+    public void testCalculateIntermediateCoordinate() {
+
+        DistanceHelper.Coordinate c1 = new DistanceHelper.Coordinate(33, -77);
+        DistanceHelper.Coordinate c2 = new DistanceHelper.Coordinate(32, -78);
+
+        DistanceHelper.Coordinate intermediate = DistanceHelper.calculateIntermediateCoordinate(c1, c2, 10000);
+    }
+
+}

--- a/src/test/java/com/redhat/cajun/navy/responder/simulator/data/ResponderTest.java
+++ b/src/test/java/com/redhat/cajun/navy/responder/simulator/data/ResponderTest.java
@@ -1,0 +1,321 @@
+package com.redhat.cajun.navy.responder.simulator.data;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.LinkedList;
+
+import org.hamcrest.number.IsCloseTo;
+import org.junit.Test;
+
+public class ResponderTest {
+
+   /**
+     *  Test description:
+     *
+     *    When :
+     *      The distance between the current location and the next step is between the reference_distance/1.3 and reference_distance*1.3
+     *
+     *    Then:
+     *      The next step remains unchanged
+     */
+    @Test
+    public void testCalculateNextLocation() {
+
+        MissionStep step1 = new MissionStep();
+        step1.setLat(33.0100);
+        step1.setLon(-77.0100);
+        step1.setWayPoint(false);
+        step1.setDestination(false);
+
+        LinkedList<MissionStep> steps = new LinkedList<>();
+        steps.add(step1);
+
+        Responder responder = new Responder();
+        responder.setQueue(steps);
+        responder.setCurrentLat(33.0000);
+        responder.setCurrentLon(-77.0000);
+        responder.setDistanceUnit(1500.0);
+
+        responder.calculateNextLocation();
+        assertThat(responder.getQueue().size(), equalTo(1));
+        assertThat(responder.getQueue().peek().getLat(), equalTo(33.0100));
+        assertThat(responder.getQueue().peek().getLon(), equalTo(-77.0100));
+    }
+
+    /**
+     *  Test description:
+     *
+     *    When :
+     *      The distance between the current location and the next step is greater than refdistance*1.3
+     *
+     *    Then:
+     *      A new step is added to the head of the steps queue
+     *      The distance between the current location and the next step is approx. equal to the reference distance
+     */
+    @Test
+    public void testCalculateNextLocation2() {
+
+        MissionStep step1 = new MissionStep();
+        step1.setLat(33.0300);
+        step1.setLon(-77.0100);
+        step1.setWayPoint(false);
+        step1.setDestination(false);
+
+        LinkedList<MissionStep> steps = new LinkedList<>();
+        steps.add(step1);
+
+        Responder responder = new Responder();
+        responder.setQueue(steps);
+        responder.setCurrentLat(33.0000);
+        responder.setCurrentLon(-77.0000);
+        responder.setDistanceUnit(1500.0);
+
+        responder.calculateNextLocation();
+        assertThat(responder.getQueue().size(), equalTo(2));
+        MissionStep step = responder.getQueue().poll();
+        assertThat(step.isDestination(), equalTo(false));
+        assertThat(step.isWayPoint(), equalTo(false));
+        double distance = DistanceHelper.calculateDistance(33.0000, -77.0000, step.getLat(),step.getLon());
+        assertThat(distance, IsCloseTo.closeTo(1500.0, 1.0));
+    }
+
+    /**
+     *  Test description:
+     *
+     *    When :
+     *      The distance between the current location and the next step is smaller than the reference_distance/1.3
+     *      The distance between the current destination and the second next step is between the reference_distance/1.3 and reference_distance*1.3
+     *
+     *    Then:
+     *      The next step is the second next step
+     */
+    @Test
+    public void testCalculateNextLocation3() {
+
+        MissionStep step1 = new MissionStep();
+        step1.setLat(33.0020);
+        step1.setLon(-77.0020);
+        step1.setWayPoint(false);
+        step1.setDestination(false);
+
+        MissionStep step2 = new MissionStep();
+        step2.setLat(33.0110);
+        step2.setLon(-77.0100);
+        step2.setWayPoint(false);
+        step2.setDestination(false);
+
+        LinkedList<MissionStep> steps = new LinkedList<>();
+        steps.add(step1);
+        steps.add(step2);
+
+        Responder responder = new Responder();
+        responder.setQueue(steps);
+        responder.setCurrentLat(33.0000);
+        responder.setCurrentLon(-77.0000);
+        responder.setDistanceUnit(1500.0);
+
+        responder.calculateNextLocation();
+        assertThat(responder.getQueue().size(), equalTo(1));
+        assertThat(responder.getQueue().peek().getLat(), equalTo(step2.getLat()));
+        assertThat(responder.getQueue().peek().getLon(), equalTo(step2.getLon()));
+    }
+
+    /**
+     *  Test description:
+     *
+     *    When :
+     *      The distance between the current location and the next step is smaller than the reference_distance/1.3
+     *      The distance between the next step and the second next step is smaller than the reference_distance/1.3
+     *      The distance between the current destination and the third next step is between the reference_distance/1.3 and reference_distance*1.3
+     *
+     *    Then:
+     *      The next step is the second next step
+     */
+    @Test
+    public void testCalculateNextLocation4() {
+
+        MissionStep step1 = new MissionStep();
+        step1.setLat(33.0020);
+        step1.setLon(-77.0020);
+        step1.setWayPoint(false);
+        step1.setDestination(false);
+
+        MissionStep step2 = new MissionStep();
+        step2.setLat(33.0040);
+        step2.setLon(-77.0040);
+        step2.setWayPoint(false);
+        step2.setDestination(false);
+
+        MissionStep step3 = new MissionStep();
+        step3.setLat(33.0100);
+        step3.setLon(-77.0100);
+        step3.setWayPoint(false);
+        step3.setDestination(false);
+
+        LinkedList<MissionStep> steps = new LinkedList<>();
+        steps.add(step1);
+        steps.add(step2);
+        steps.add(step3);
+
+        Responder responder = new Responder();
+        responder.setQueue(steps);
+        responder.setCurrentLat(33.0000);
+        responder.setCurrentLon(-77.0000);
+        responder.setDistanceUnit(1500.0);
+
+        responder.calculateNextLocation();
+        assertThat(responder.getQueue().size(), equalTo(1));
+        assertThat(responder.getQueue().peek().getLat(), equalTo(step3.getLat()));
+        assertThat(responder.getQueue().peek().getLon(), equalTo(step3.getLon()));
+    }
+
+    /**
+     *  Test description:
+     *
+     *    When :
+     *      The distance between the current location and the next step is smaller than the reference_distance/1.3
+     *      The distance between the next step and the second next step is smaller than the reference_distance/1.3
+     *      The distance between the current destination and the third next step is greater than the reference_distance*1.3
+     *
+     *    Then:
+     *      A new step is added before the third next step at the head of the queue
+     *      The distance between the current location and the next step is approx. equal to the reference distance
+     */
+    @Test
+    public void testCalculateNextLocation5() {
+
+        MissionStep step1 = new MissionStep();
+        step1.setLat(33.0020);
+        step1.setLon(-77.0020);
+        step1.setWayPoint(false);
+        step1.setDestination(false);
+
+        MissionStep step2 = new MissionStep();
+        step2.setLat(33.0040);
+        step2.setLon(-77.0040);
+        step2.setWayPoint(false);
+        step2.setDestination(false);
+
+        MissionStep step3 = new MissionStep();
+        step3.setLat(33.0200);
+        step3.setLon(-77.0200);
+        step3.setWayPoint(false);
+        step3.setDestination(false);
+
+        LinkedList<MissionStep> steps = new LinkedList<>();
+        steps.add(step1);
+        steps.add(step2);
+        steps.add(step3);
+
+        Responder responder = new Responder();
+        responder.setQueue(steps);
+        responder.setCurrentLat(33.0000);
+        responder.setCurrentLon(-77.0000);
+        responder.setDistanceUnit(1500.0);
+
+        responder.calculateNextLocation();
+        assertThat(responder.getQueue().size(), equalTo(2));
+
+        double distance1 = DistanceHelper.calculateDistance(33.0000, -77.0000, step1.getLat(), step1.getLon());
+        double distance2 = DistanceHelper.calculateDistance(step1.getLat(), step1.getLon(), step2.getLat(), step2.getLon());
+        double distance3 = DistanceHelper.calculateDistance(step2.getLat(), step2.getLon(), responder.getQueue().peek().getLat(), responder.getQueue().peek().getLon());
+
+        double distance = distance1 + distance2 + distance3;
+        assertThat(distance, IsCloseTo.closeTo(1500.0, 10.0));
+    }
+
+    /**
+     *  Test description:
+     *
+     *    When :
+     *      The distance between the current location and the next step is smaller than the reference_distance/1.3
+     *      The next step is a waypoint
+     *
+     *    Then:
+     *      The next step remains unchanged
+     */
+    @Test
+    public void testCalculateNextLocation6() {
+
+        MissionStep step1 = new MissionStep();
+        step1.setLat(33.0020);
+        step1.setLon(-77.0020);
+        step1.setWayPoint(true);
+        step1.setDestination(false);
+
+        MissionStep step2 = new MissionStep();
+        step2.setLat(33.0110);
+        step2.setLon(-77.0100);
+        step2.setWayPoint(true);
+        step2.setDestination(false);
+
+        LinkedList<MissionStep> steps = new LinkedList<>();
+        steps.add(step1);
+        steps.add(step2);
+
+        Responder responder = new Responder();
+        responder.setQueue(steps);
+        responder.setCurrentLat(33.0000);
+        responder.setCurrentLon(-77.0000);
+        responder.setDistanceUnit(1500.0);
+
+        responder.calculateNextLocation();
+        assertThat(responder.getQueue().size(), equalTo(2));
+        assertThat(responder.getQueue().peek().getLat(), equalTo(step1.getLat()));
+        assertThat(responder.getQueue().peek().getLon(), equalTo(step1.getLon()));
+    }
+
+    /**
+     *  Test description:
+     *
+     *    When :
+     *      The distance between the current location and the next step is smaller than the reference_distance/1.3
+     *      The next step is a destination
+     *
+     *    Then:
+     *      The next step remains unchanged
+     */
+    @Test
+    public void testCalculateNextLocation7() {
+
+        MissionStep step1 = new MissionStep();
+        step1.setLat(33.0020);
+        step1.setLon(-77.0020);
+        step1.setWayPoint(false);
+        step1.setDestination(true);
+
+        MissionStep step2 = new MissionStep();
+        step2.setLat(33.0110);
+        step2.setLon(-77.0100);
+        step2.setWayPoint(true);
+        step2.setDestination(false);
+
+        LinkedList<MissionStep> steps = new LinkedList<>();
+        steps.add(step1);
+        steps.add(step2);
+
+        Responder responder = new Responder();
+        responder.setQueue(steps);
+        responder.setCurrentLat(33.0000);
+        responder.setCurrentLon(-77.0000);
+        responder.setDistanceUnit(1500.0);
+
+        responder.calculateNextLocation();
+        assertThat(responder.getQueue().size(), equalTo(2));
+        assertThat(responder.getQueue().peek().getLat(), equalTo(step1.getLat()));
+        assertThat(responder.getQueue().peek().getLon(), equalTo(step1.getLon()));
+    }
+
+
+    private static double round(double value, int places) {
+        if (places < 0) throw new IllegalArgumentException();
+
+        BigDecimal bd = new BigDecimal(Double.toString(value));
+        bd = bd.setScale(places, RoundingMode.HALF_UP);
+        return bd.doubleValue();
+    }
+
+}


### PR DESCRIPTION
In the current responder simulator, the responders move along the route coordinates provided by Mapbox, moving to the next coordinate at each simulation cycle. The distance between consecutive coordinates obtained from MapBox varies greatly, from a couple of meters to several kilometers. As a result the responders move at very divergent speeds.
This pull request tries to make sure that the responders move at more even speed. When MapBox coordinates are close to each other, several coordinates are consumed in one cycle. When they are more distant, intermediate coordinates are calculated.
The distance unit defaults to 1500 meter per simulation cycle (with a tolerance of 30%). This default value is configurable (configuration property `simulator.distance.unit`)