### PR TITLE
Shutdown vert.x if any of the verticles fail at startup.

### DIFF
--- a/src/main/java/com/redhat/cajun/navy/responder/simulator/Main.java
+++ b/src/main/java/com/redhat/cajun/navy/responder/simulator/Main.java
@@ -63,6 +63,7 @@ public class Main extends AbstractVerticle {
             } else {
                 logger.error("WARNINIG: Verticles NOT deployed successfully.");
                 future.fail(ar.cause());
+                vertx.close();
             }
         });
 
@@ -83,6 +84,7 @@ public class Main extends AbstractVerticle {
                     } else {
                         logger.fatal("Failed to retrieve the configuration.");
                         future.fail(ar.cause());
+                        vertx.close();
                     }
                 });
     }


### PR DESCRIPTION
Doing so will prevent the RESTful /metrics endpoint from being available.
Lifecycle probe will subsequently trigger.

This commit fixes the issue that tends occur after a full OCP restart where responder-simulator pod starts before network is ready.  In particular, responder-simulator is unable to resolve  kafka-cluster-kafka-bootstrap service.


https://trello.com/c/5CvkymVY/148-increase-resilience-of-responder-simulator-service